### PR TITLE
fix pdf of normal distribution

### DIFF
--- a/lib/scixir/distributions.ex
+++ b/lib/scixir/distributions.ex
@@ -3,8 +3,8 @@ defmodule Scixir.Distributions do
 
   def pdf_norm(x, mu, sd) do
     pi = :math.pi()
-    expon = - Math.pow((x - mu) / sd, 2)) / 2 
-    denom = 1 / (pi * Math.pow(2 * pi, 0.5))
+    expon = - Math.pow((x - mu) / sd, 2)) / 2
+    denom = 1 / (sd * Math.pow(2 * pi, 0.5))
     :math.e(expon) * denom
   end
 end


### PR DESCRIPTION
denominator currently has two `pi`, one inside sqrt and one outside, the outside one should be `sd` not `pi`, see the pdf below from Wikipedia.

![](https://wikimedia.org/api/rest_v1/media/math/render/svg/00cb9b2c9b866378626bcfa45c86a6de2f2b2e40)